### PR TITLE
Fix/fix true name when generate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ public
 .eslintrc
 .sass-lint.yml
 .scss-lint.yml
+.nvmrc


### PR DESCRIPTION
Please review @carlosvillu @kikoruiz 

* Generate correctly package name instead `@true/true-true-true: true` hahaha :)
* Remove not needed first line as it's incorrect for the linter.
* Check for category and give an error as it should be required as well.
* Simplify paths with two constants: COMPONENT_DIR and DEMO_DIR.
* Added .nvmrc file to .gitignore (sorry guys, I use it and is a pain in the ass if I have to change manually the node version always).