### PR TITLE
fix(cli): Fix wrong created cz-config file

### DIFF
--- a/bin/suistudio-init.js
+++ b/bin/suistudio-init.js
@@ -120,7 +120,7 @@ const readFileSync = require('fs').readFileSync
 
 var packageScopes = readFileSync('./.COMPONENTS', 'utf8')
                       .trim()
-                      .split('\n')
+                      .split('\\n')
                       .sort()
 
 var otherScopes = [


### PR DESCRIPTION
This PR fixes issue #36

Basically, adding a slash to avoid writing line-break as it is.