### PR TITLE
Refactor/remove need of components file

### DIFF
--- a/bin/shared.js
+++ b/bin/shared.js
@@ -1,12 +1,20 @@
-const readFileSync = require('fs').readFileSync
+const readdirSync = require('fs').readdirSync
+const statSync = require('fs').statSync
+const path = require('path')
 
-const cwds = (baseDir, componentsList) => {
-  return readFileSync(componentsList, 'utf8')
-    .trim()
-    .split('\n')
-    .map(pkg => `${baseDir}/components/${pkg}`)
+const onlyFolders = (rootPath, fileName) => {
+  return statSync(path.join(rootPath, fileName)).isDirectory()
 }
 
 module.exports = {
-  cwds: cwds
+  cwds: (baseDir) => {
+    const rootDir = path.join(baseDir, 'components')
+
+    return readdirSync(rootDir)
+      .filter(file => onlyFolders(rootDir, file))
+      .map(folder => readdirSync(path.join(rootDir, folder))
+        .filter(file => onlyFolders(path.join(rootDir, folder), file))
+        .map(file => path.join(rootDir, folder, file))
+      ).reduce((x, y) => x.concat(y)) // flatten
+  }
 }

--- a/bin/shared.js
+++ b/bin/shared.js
@@ -6,15 +6,23 @@ const onlyFolders = (rootPath, fileName) => {
   return statSync(path.join(rootPath, fileName)).isDirectory()
 }
 
-module.exports = {
-  cwds: (baseDir) => {
-    const rootDir = path.join(baseDir, 'components')
+const cwds = (baseDir) => {
+  const rootDir = path.join(baseDir, 'components')
 
-    return readdirSync(rootDir)
-      .filter(file => onlyFolders(rootDir, file))
-      .map(folder => readdirSync(path.join(rootDir, folder))
-        .filter(file => onlyFolders(path.join(rootDir, folder), file))
-        .map(file => path.join(rootDir, folder, file))
-      ).reduce((x, y) => x.concat(y)) // flatten
+  return readdirSync(rootDir)
+    .filter(file => onlyFolders(rootDir, file))
+    .map(folder => readdirSync(path.join(rootDir, folder))
+      .filter(file => onlyFolders(path.join(rootDir, folder), file))
+      .map(file => path.join(rootDir, folder, file))
+    ).reduce((x, y) => x.concat(y)) // flatten
+}
+
+module.exports = {
+  cwds: cwds,
+  components: (baseDir) => {
+    return cwds(baseDir).map(folder => {
+      const [component, category] = folder.split('/').reverse()
+      return `${category}/${component}`
+    })
   }
 }

--- a/bin/shared.js
+++ b/bin/shared.js
@@ -1,0 +1,12 @@
+const readFileSync = require('fs').readFileSync
+
+const cwds = (baseDir, componentsList) => {
+  return readFileSync(componentsList, 'utf8')
+    .trim()
+    .split('\n')
+    .map(pkg => `${baseDir}/components/${pkg}`)
+}
+
+module.exports = {
+  cwds: cwds
+}

--- a/bin/suistudio-check-release.js
+++ b/bin/suistudio-check-release.js
@@ -1,14 +1,9 @@
 /* eslint no-console:0 */
 
 const conventionalChangelog = require('conventional-changelog')
-const readFileSync = require('fs').readFileSync
-
 const BASE_DIR = process.cwd()
-const COMPONENTS_LIST = `${BASE_DIR}/.COMPONENTS`
 
-var packagesWithChangelog = readFileSync(COMPONENTS_LIST, 'utf8')
-                              .trim()
-                              .split('\n')
+const packagesWithChangelog = require('./shared').components(BASE_DIR)
 
 let status = {}
 packagesWithChangelog.forEach((pkg) => {

--- a/bin/suistudio-check-release.js
+++ b/bin/suistudio-check-release.js
@@ -3,7 +3,7 @@
 const conventionalChangelog = require('conventional-changelog')
 const BASE_DIR = process.cwd()
 
-const packagesWithChangelog = require('./shared').components(BASE_DIR)
+const packagesWithChangelog = require('./walker').componentsName(BASE_DIR)
 
 let status = {}
 packagesWithChangelog.forEach((pkg) => {

--- a/bin/suistudio-clean-modules.js
+++ b/bin/suistudio-clean-modules.js
@@ -3,7 +3,7 @@
 const colors = require('colors')
 const {remove} = require('fs-extra')
 const BASE_DIR = process.cwd()
-const cwds = require('./shared').cwds(BASE_DIR)
+const cwds = require('./walker').componentsFullPath(BASE_DIR)
 
 const removeNodeModulesFolder = (cwd) => {
   const [component, category] = cwd.split('/').reverse()

--- a/bin/suistudio-clean-modules.js
+++ b/bin/suistudio-clean-modules.js
@@ -1,13 +1,10 @@
 /* eslint no-console:0 */
 
 const colors = require('colors')
-const {remove, readFileSync} = require('fs-extra')
+const {remove} = require('fs-extra')
 const BASE_DIR = process.cwd()
 const COMPONENTS_LIST = `${BASE_DIR}/.COMPONENTS`
-const cwds = readFileSync(COMPONENTS_LIST, 'utf8')
-                              .trim()
-                              .split('\n')
-                              .map(pkg => `${BASE_DIR}/components/${pkg}`)
+const cwds = require('./shared').cwds(BASE_DIR, COMPONENTS_LIST)
 
 const removeNodeModulesFolder = (cwd) => {
   const [component, category] = cwd.split('/').reverse()

--- a/bin/suistudio-clean-modules.js
+++ b/bin/suistudio-clean-modules.js
@@ -3,8 +3,7 @@
 const colors = require('colors')
 const {remove} = require('fs-extra')
 const BASE_DIR = process.cwd()
-const COMPONENTS_LIST = `${BASE_DIR}/.COMPONENTS`
-const cwds = require('./shared').cwds(BASE_DIR, COMPONENTS_LIST)
+const cwds = require('./shared').cwds(BASE_DIR)
 
 const removeNodeModulesFolder = (cwd) => {
   const [component, category] = cwd.split('/').reverse()

--- a/bin/suistudio-generate.js
+++ b/bin/suistudio-generate.js
@@ -50,10 +50,6 @@ const COMPONENT_PLAYGROUND_FILE = `${DEMO_DIR}playground`
 const COMPONENT_CONTEXT_FILE = `${DEMO_DIR}context.js`
 const COMPONENT_ROUTES_FILE = `${DEMO_DIR}routes.js`
 
-const COMPONENTS_LIST = `${BASE_DIR}/.COMPONENTS`
-
-fse.appendFileSync(COMPONENTS_LIST, `${category}/${component}\n`)
-
 const writeFile = (path, body) => {
   fse.outputFile(
     path,

--- a/bin/suistudio-init.js
+++ b/bin/suistudio-init.js
@@ -38,11 +38,6 @@ createDir(`${BASE_DIR}/${PROJECT_NAME}/components`)
 createDir(`${BASE_DIR}/${PROJECT_NAME}/demo`)
 
 writeFile(
-`${BASE_DIR}/${PROJECT_NAME}/.COMPONENTS`,
-''
-)
-
-writeFile(
 `${BASE_DIR}/${PROJECT_NAME}/components/README.md`,
 '# Here put a description about your project'
 )
@@ -116,12 +111,25 @@ writeFile(
 writeFile(
 `${BASE_DIR}/${PROJECT_NAME}/.cz-config.js`,
 `
-const readFileSync = require('fs').readFileSync
+const readdirSync = require('fs').readdirSync
+const statSync = require('fs').statSync
+const path = require('path')
+const BASE_DIR = process.cwd() + '/components'
 
-var packageScopes = readFileSync('./.COMPONENTS', 'utf8')
-                      .trim()
-                      .split('\\n')
-                      .sort()
+const onlyFolders = (filePath) => statSync(filePath).isDirectory()
+const flatten = (x, y) => x.concat(y)
+
+var packageScopes = readdirSync(BASE_DIR)
+  .map(file => path.join(BASE_DIR, file))
+  .filter(onlyFolders)
+  .map(folder => readdirSync(folder)
+    .map(file => path.join(folder, file))
+    .filter(onlyFolders)
+  ).reduce(flatten, [])
+  .map(folder => {
+    const [component, category] = folder.split('/').reverse()
+    return category + '/' + component
+  })
 
 var otherScopes = [
   'META',

--- a/bin/suistudio-release.js
+++ b/bin/suistudio-release.js
@@ -18,7 +18,7 @@ const releasesByPackages = (pkg) => {
   })
 }
 
-const releasesStatus = require('./shared').components(BASE_DIR).map(releasesByPackages)
+const releasesStatus = require('./walker').componentsName(BASE_DIR).map(releasesByPackages)
 
 const releaseEachPkg = ({pkg, code} = {}) => {
   return new Promise((resolve, reject) => {

--- a/bin/suistudio-release.js
+++ b/bin/suistudio-release.js
@@ -1,9 +1,7 @@
 /* eslint no-console:0 */
 
 const spawn = require('child_process').spawn
-const readFileSync = require('fs').readFileSync
 const BASE_DIR = process.cwd()
-const COMPONENTS_LIST = `${BASE_DIR}/.COMPONENTS`
 
 const RELEASE_CODES = {
   0: 'clean',
@@ -20,10 +18,7 @@ const releasesByPackages = (pkg) => {
   })
 }
 
-const releasesStatus = readFileSync(COMPONENTS_LIST, 'utf8')
-                              .trim()
-                              .split('\n')
-                              .map(releasesByPackages)
+const releasesStatus = require('./shared').components(BASE_DIR).map(releasesByPackages)
 
 const releaseEachPkg = ({pkg, code} = {}) => {
   return new Promise((resolve, reject) => {

--- a/bin/suistudio-run-all.js
+++ b/bin/suistudio-run-all.js
@@ -2,15 +2,11 @@
 
 const colors = require('colors')
 const spawn = require('child_process').spawn
-const readFileSync = require('fs').readFileSync
 const program = require('commander')
 const BASE_DIR = process.cwd()
 const CODE_OK = 0
 const COMPONENTS_LIST = `${BASE_DIR}/.COMPONENTS`
-const cwds = readFileSync(COMPONENTS_LIST, 'utf8')
-                              .trim()
-                              .split('\n')
-                              .map(pkg => `${BASE_DIR}/components/${pkg}`)
+const cwds = require('./shared').cwds(BASE_DIR, COMPONENTS_LIST)
 
 program
   .parse(process.argv)

--- a/bin/suistudio-run-all.js
+++ b/bin/suistudio-run-all.js
@@ -5,8 +5,7 @@ const spawn = require('child_process').spawn
 const program = require('commander')
 const BASE_DIR = process.cwd()
 const CODE_OK = 0
-const COMPONENTS_LIST = `${BASE_DIR}/.COMPONENTS`
-const cwds = require('./shared').cwds(BASE_DIR, COMPONENTS_LIST)
+const cwds = require('./shared').cwds(BASE_DIR)
 
 program
   .parse(process.argv)

--- a/bin/suistudio-run-all.js
+++ b/bin/suistudio-run-all.js
@@ -5,7 +5,7 @@ const spawn = require('child_process').spawn
 const program = require('commander')
 const BASE_DIR = process.cwd()
 const CODE_OK = 0
-const cwds = require('./shared').cwds(BASE_DIR)
+const cwds = require('./walker').componentsFullPath(BASE_DIR)
 
 program
   .parse(process.argv)

--- a/bin/walker.js
+++ b/bin/walker.js
@@ -2,18 +2,17 @@ const readdirSync = require('fs').readdirSync
 const statSync = require('fs').statSync
 const path = require('path')
 
-const onlyFolders = (rootPath, fileName) => {
-  return statSync(path.join(rootPath, fileName)).isDirectory()
-}
+const onlyFolders = (filePath) => statSync(filePath).isDirectory()
 
 const cwds = (baseDir) => {
   const rootDir = path.join(baseDir, 'components')
 
   return readdirSync(rootDir)
-    .filter(file => onlyFolders(rootDir, file))
-    .map(folder => readdirSync(path.join(rootDir, folder))
-      .filter(file => onlyFolders(path.join(rootDir, folder), file))
-      .map(file => path.join(rootDir, folder, file))
+    .map(file => path.join(rootDir, file))
+    .filter(onlyFolders)
+    .map(folder => readdirSync(folder)
+      .map(file => path.join(folder, file))
+      .filter(onlyFolders)
     ).reduce((x, y) => x.concat(y)) // flatten
 }
 

--- a/bin/walker.js
+++ b/bin/walker.js
@@ -3,6 +3,7 @@ const statSync = require('fs').statSync
 const path = require('path')
 
 const onlyFolders = (filePath) => statSync(filePath).isDirectory()
+const flatten = (x, y) => x.concat(y)
 
 const cwds = (baseDir) => {
   const rootDir = path.join(baseDir, 'components')
@@ -13,7 +14,7 @@ const cwds = (baseDir) => {
     .map(folder => readdirSync(folder)
       .map(file => path.join(folder, file))
       .filter(onlyFolders)
-    ).reduce((x, y) => x.concat(y)) // flatten
+    ).reduce(flatten, [])
 }
 
 module.exports = {

--- a/bin/walker.js
+++ b/bin/walker.js
@@ -18,8 +18,8 @@ const cwds = (baseDir) => {
 }
 
 module.exports = {
-  cwds: cwds,
-  components: (baseDir) => {
+  componentsFullPath: cwds,
+  componentsName: (baseDir) => {
     return cwds(baseDir).map(folder => {
       const [component, category] = folder.split('/').reverse()
       return `${category}/${component}`


### PR DESCRIPTION
This PR removes the need of the  `.COMPONENTS` file.

Instead it uses the contract of `components/$category/$component` folder structure to parse the components list and provide the list of components.

This PR has been tested against all the commands modified by it.
The UI has been also tested to ensure that nothing was relying from `.COMPONENTS` in a hidden way

Method of testing:
- Init a project
- Generate a few components
- Test a commit to ensure scopes are being taken into account in cz
- check release
- release (release fails badly when it's nothing to release but in master has the same behaviour)
- run-all and run npm i
- clean-modules