### PR TITLE
Bugfix/components with dashed names

### DIFF
--- a/src/components/demo/fetch-styles.js
+++ b/src/components/demo/fetch-styles.js
@@ -2,7 +2,7 @@
 /* global __BASE_DIR__ */
 
 const reqThemePlayGround = require.context(`!css-content-loader!css-loader!sass-loader!${__BASE_DIR__}/demo`, true, /^.*\/themes\/.*\.scss/)
-const reqComponentsSCSS = require.context(`!css-content-loader!css-loader!sass-loader!${__BASE_DIR__}/components`, true, /^\.\/\w+\/\w+\/src\/index\.scss/)
+const reqComponentsSCSS = require.context(`!css-content-loader!css-loader!sass-loader!${__BASE_DIR__}/components`, true, /^\.\/[\w-]+\/[\w-]+\/src\/index\.scss/)
 
 export const themesFor = ({category, component}) =>
   reqThemePlayGround.keys()

--- a/src/components/demo/try-require.js
+++ b/src/components/demo/try-require.js
@@ -1,7 +1,7 @@
 /* global __BASE_DIR__ */
 
 const reqComponentsSrc =
-  require.context(`bundle-loader?lazy!${__BASE_DIR__}/components`, true, /^\.\/\w+\/\w+\/src\/index\.jsx?/)
+  require.context(`bundle-loader?lazy!${__BASE_DIR__}/components`, true, /^\.\/[\w-]+\/[\w-]+\/src\/index\.jsx?/)
 const reqComponentsPlayGround =
   require.context(`bundle-loader?lazy!raw-loader!${__BASE_DIR__}/demo`, true, /^.*\/playground/)
 const reqContextPlayGround =

--- a/src/components/navigation/index.js
+++ b/src/components/navigation/index.js
@@ -3,7 +3,7 @@
 import React, {PropTypes} from 'react'
 import {Link} from 'react-router'
 
-const reqPackages = require.context(`${__BASE_DIR__}/components`, true, /^\.\/\w+\/\w+\/package\.json/)
+const reqPackages = require.context(`${__BASE_DIR__}/components`, true, /^\.\/[\w-]+\/[\w-]+\/package\.json/)
 
 export default class Navigation extends React.Component {
   propTypes = {


### PR DESCRIPTION
Fixes #41 

**The problem:** `\w` matcher is the equivalent to: `[a-zA-Z_]+` this means that any folder with `-` does not match the regex and gets excluded.

**The solution:** Add the `-` symbol to be valid in the regex that parses the `components` folder. This was required in the `navigation` bar, `fetch-styles` and `try-require`

**Testing:** Test performed to validate the issue where:

- Create a new sui studio
- Crete two components (test/test and test/test-dash)
- Start the UI (suistudio start) and validate that the component is displayed and the demo is correctly loaded

**Others:**

Keep in mind that this will be included in the `3.0.0-beta.0@beta` release. Should I create a branch for providing a fix to the current `2.7` version?